### PR TITLE
Running as a Dogebox "Pup"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,7 @@ build
 
 # Go workspace file
 go.work
+
+# App specific
+dogemap
+dogemap.db

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ For Linux:
 6. Open the provided browser URL:
 
    ```
-    http://localhost:8080
+    http://localhost:9090
    ```
 
 You will see the map running :)

--- a/cmd/dogemap/main.go
+++ b/cmd/dogemap/main.go
@@ -12,8 +12,8 @@ func main() {
 	go func() {
 		// Serve index.html using an HTTP server
 		http.Handle("/", http.FileServer(http.Dir("pkg/dogemap")))
-		fmt.Println("Server running at http://localhost:8080")
-		http.ListenAndServe(":8080", nil)
+		fmt.Println("Server running at http://localhost:9090")
+		http.ListenAndServe(":9090", nil)
 	}()
 
 	// Run the handshake script periodically

--- a/pkg/dogemap/index.html
+++ b/pkg/dogemap/index.html
@@ -15,6 +15,7 @@
   <script src="//unpkg.com/d3-geo-projection"></script>
   <script src='//unpkg.com/simple-statistics'></script>
   <body class="dark-mode">
+    <script type="module" src="http://dogebox.local:8080/static/dogebox-toolkit/index.js"></script>
     <!-- Loading image -->
     <div id="much-loading-image">
         <img src="img/DogeMap-loading.gif" alt="Much Loading DogeMap...">

--- a/pkg/dogemap/scripts/dogemap.js
+++ b/pkg/dogemap/scripts/dogemap.js
@@ -361,7 +361,21 @@ function getUniqueSubvers(data) {
      // Initialize the map
      //const world = await d3.json('./dogeWorld.json');
      //ready(world, data);
+
+      window.addEventListener('resize', debounce(() => ready(geoData, data), 300));
  }
 
  // Call initialize function when the DOM content is loaded
  document.addEventListener('DOMContentLoaded', initialize);
+
+function debounce(func, wait) {
+  let timeout;
+  return function executedFunction(...args) {
+    const later = () => {
+      clearTimeout(timeout);
+      func(...args);
+    };
+    clearTimeout(timeout);
+    timeout = setTimeout(later, wait);
+  };
+}


### PR DESCRIPTION
This PR does a couple of things to allow Dogemap to run as a Dogebox pup

![image](https://github.com/dogeorg/dogemap/assets/151626101/4a65e2bb-ff9d-45b2-b555-7d6d7637422f)

Changes are:

1. It adds the dogebox toolkit script.  Essential for all pups to load so that Pups and Dpanel can communicate via postMessage (common between iframe parent and child), in order to share window dimensions, affect the URL, and a few other things.

2. Updates the map size on window resize.  Debounces this, so it will only occur once every 300ms when actively resizing.

3. Adjusts port to 9090, so it does not clash with dpanels 8080.

---

To test this, 

1. Have this repository and dpanel cloned locally.
2. Within dpanel/dev directory,  run `npm run setup && npm start`
3. Build and run dogemap
4. Then visit:  http://dogebox.local:8080 and click on the Map link


